### PR TITLE
Fix issue #1: Sorting stay on "armor sort" no matter what choosed in …

### DIFF
--- a/r6/scripts/VendorUIImprovements/ArmorRaritySort.reds
+++ b/r6/scripts/VendorUIImprovements/ArmorRaritySort.reds
@@ -1,7 +1,7 @@
 module VendorUIImprovements.ArmorRaritySort
 
 @addField(ScriptableDataView)
-public let m_itemSortMode: ItemSortMode;
+public let m_itemSortModeUtils: ItemSortMode;
 
 @addMethod(ScriptableDataView)
 public func PreSortingInjection(builder: ref<ItemCompareBuilder>) -> ref<ItemCompareBuilder> {}
@@ -9,7 +9,7 @@ public func PreSortingInjection(builder: ref<ItemCompareBuilder>) -> ref<ItemCom
 @wrapMethod(BackpackDataView)
 public final func SetSortMode(mode: ItemSortMode) -> Void {
   if VuiMod.Get().SectionArmorRaritySort {
-    super.m_itemSortMode = mode; /* VuiMod */
+    super.m_itemSortModeUtils = mode; /* VuiMod */
     wrappedMethod(mode);
   } else {
     wrappedMethod(mode);
@@ -19,7 +19,7 @@ public final func SetSortMode(mode: ItemSortMode) -> Void {
 @wrapMethod(CraftingDataView)
 public final func SetSortMode(mode: ItemSortMode) -> Void {
   if VuiMod.Get().SectionArmorRaritySort {
-    super.m_itemSortMode = mode; /* VuiMod */
+    super.m_itemSortModeUtils = mode; /* VuiMod */
     wrappedMethod(mode);
   } else {
     wrappedMethod(mode);
@@ -29,7 +29,7 @@ public final func SetSortMode(mode: ItemSortMode) -> Void {
 @wrapMethod(CyberwareDataView)
 public final func SetSortMode(mode: ItemSortMode) -> Void {
   if VuiMod.Get().SectionArmorRaritySort {
-    super.m_itemSortMode = mode; /* VuiMod */
+    super.m_itemSortModeUtils = mode; /* VuiMod */
     wrappedMethod(mode);
   } else {
     wrappedMethod(mode);
@@ -39,7 +39,7 @@ public final func SetSortMode(mode: ItemSortMode) -> Void {
 @wrapMethod(ItemModeGridView)
 public final func SetSortMode(mode: ItemSortMode) -> Void {
   if VuiMod.Get().SectionArmorRaritySort {
-    super.m_itemSortMode = mode; /* VuiMod */
+    super.m_itemSortModeUtils = mode; /* VuiMod */
     wrappedMethod(mode);
   } else {
     wrappedMethod(mode);

--- a/r6/scripts/VendorUIImprovements/init.reds
+++ b/r6/scripts/VendorUIImprovements/init.reds
@@ -281,7 +281,7 @@ public class VuiMod {
       compareBuilder = dataView.PreSortingInjection(compareBuilder);
     }
 
-    if Equals(dataView.m_itemSortMode, ItemSortMode.NewItems) {
+    if Equals(dataView.m_itemSortModeUtils, ItemSortMode.NewItems) {
       if isInventory {
         return this.DefaultSort(this.ArmorDesc(compareBuilder.NewItem(uiScriptableSystem).DPSDesc()));
       } else {
@@ -294,7 +294,7 @@ public class VuiMod {
     }
 
     if VuiMod.Get().OptionTrueSorting {
-      switch dataView.m_itemSortMode {
+      switch dataView.m_itemSortModeUtils {
         case ItemSortMode.NameAsc:
           return compareBuilder.NameAsc().GetBool();
         case ItemSortMode.NameDesc:
@@ -319,7 +319,7 @@ public class VuiMod {
           return compareBuilder.ItemType().QualityDesc().PriceDesc().GetBool();
       };
     } else {
-      switch dataView.m_itemSortMode {
+      switch dataView.m_itemSortModeUtils {
         case ItemSortMode.NameAsc:
           return compareBuilder.NameAsc().QualityDesc().GetBool();
         case ItemSortMode.NameDesc:


### PR DESCRIPTION
…sort select menu

Seems that touching `m_itemSortMode` variable is a bad idea

Verified on `1.61 DLSS3` - Cyber Engine Tweaks CET `1.23.0` - redscript `0.5.10` - cybercmd `0.0.6`

Inventory:

- Default (damage/armor) sort: `descending` works
- New items sort: `descending` works
- Name sort: `ascending` works - `descending` works
- Damage/Armor sort: `descending` works - `ascending` works
- Rarity sort: `descending` works - `ascending` works
- Weight sort: `descending` works - `ascending` works
- Price sort: `descending` works - `ascending` works

Cyberware: all working
Crafting: `upgrade` all working, `create` all working
Backpack: not working